### PR TITLE
Add missing htmlunit lib to dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <version.jjwt>0.11.2</version.jjwt>
         <version.quarkus.qpid.jms>0.24.0</version.quarkus.qpid.jms>
         <version.apache.avro>1.10.2</version.apache.avro>
+        <version.htmlunit>2.40.0</version.htmlunit>
         <version.keytool-maven-plugin>1.5</version.keytool-maven-plugin>
         <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
         <version.maven-jar-plugin>3.2.0</version.maven-jar-plugin>
@@ -173,6 +174,11 @@
                 <groupId>org.amqphub.quarkus</groupId>
                 <artifactId>quarkus-qpid-jms</artifactId>
                 <version>${version.quarkus.qpid.jms}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.sourceforge.htmlunit</groupId>
+                <artifactId>htmlunit</artifactId>
+                <version>${version.htmlunit}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
The library is missing in the `quarkus-bom` and also will be removed from `quarkus-universe-bom`, so it should be added separately (It cannot be resolved by BOM file anymore)