### PR TITLE
Add Quarkus junit5 to external app module

### DIFF
--- a/external-applications/quarkus-workshop-super-heroes/pom.xml
+++ b/external-applications/quarkus-workshop-super-heroes/pom.xml
@@ -26,6 +26,11 @@
             <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <testResources>

--- a/external-applications/quickstart-using-s2i/pom.xml
+++ b/external-applications/quickstart-using-s2i/pom.xml
@@ -16,6 +16,11 @@
             <artifactId>common</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <testResources>

--- a/external-applications/todo-demo-app/pom.xml
+++ b/external-applications/todo-demo-app/pom.xml
@@ -16,6 +16,11 @@
             <artifactId>common</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <testResources>


### PR DESCRIPTION
External app modules are throwing an exception on Jenkins pipelines because are missing this library:

```
org.junit.platform:junit-platform-launcher:jar:1.7.2:test
```
